### PR TITLE
Fix: Recent Posts Widget Not Styled on Mobile

### DIFF
--- a/style.css
+++ b/style.css
@@ -2210,6 +2210,12 @@ ul.header-search-cart .header-cart-link .count {
   font-size: 16px;
 }
 
+@media(max-width: 575px) {
+  .airi_recent_entries h5 {
+    margin-top: 20px;
+  }
+}
+
 /*--------------------------------------------------------------
 Social
 --------------------------------------------------------------*/


### PR DESCRIPTION
Based on issue tracker at [Notion](https://www.notion.so/athemes/Recent-Posts-Widget-Not-Styled-on-Mobile-c8ee12fcfef844e2ba2aa04f8533e547).

Before:
![Screen Shot 2021-10-02 at 12 01 07](https://user-images.githubusercontent.com/1859092/135704201-64a6b809-1d1c-4b88-aaaa-71b710f2ae66.png)

After:
![Screen Shot 2021-10-02 at 12 02 03](https://user-images.githubusercontent.com/1859092/135704230-f21ff8ea-6b6d-4d27-afa9-a938254feaa4.png)
 
